### PR TITLE
Add migration for missing kurra_apps columns

### DIFF
--- a/database/migrations/2026_02_15_183222_add_missing_columns_to_kurra_apps_table.php
+++ b/database/migrations/2026_02_15_183222_add_missing_columns_to_kurra_apps_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('kurra_apps', function (Blueprint $table) {
+            $table->string('current_salary')->nullable();
+            $table->string('expected_salary')->nullable();
+            $table->string('is_convicted')->nullable();
+            $table->string('convicted')->nullable();
+            $table->string('is_dismissed')->nullable();
+            $table->string('dismissed')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('kurra_apps', function (Blueprint $table) {
+            $table->dropColumn([
+                'current_salary',
+                'expected_salary',
+                'is_convicted',
+                'convicted',
+                'is_dismissed',
+                'dismissed'
+            ]);
+        });
+    }
+};


### PR DESCRIPTION
Creates a new migration to add missing columns to existing kurra_apps table:
- current_salary
- expected_salary
- is_convicted
- convicted
- is_dismissed
- dismissed

This fixes the migration failure when creating the applicant_data view on production servers where the table already exists.

https://claude.ai/code/session_018kCGjvLLQx9gtM7Ym5YNe5