### PR TITLE
Add missing signed column to jobapps table

### DIFF
--- a/database/migrations/2020_04_04_070301_create_jobapps_table.php
+++ b/database/migrations/2020_04_04_070301_create_jobapps_table.php
@@ -20,8 +20,9 @@ class CreateJobappsTable extends Migration
             $table->string('app_date')->nullable();
             $table->string('app_status')->nullable();
             $table->string('app_email')->nullable();
-            $table->string('app_id')->nullable();  
-            $table->string('status')->nullable();          
+            $table->string('app_id')->nullable();
+            $table->string('status')->nullable();
+            $table->string('signed')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2026_02_15_184426_add_signed_column_to_jobapps_table.php
+++ b/database/migrations/2026_02_15_184426_add_signed_column_to_jobapps_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('jobapps', function (Blueprint $table) {
+            $table->string('signed')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('jobapps', function (Blueprint $table) {
+            $table->dropColumn('signed');
+        });
+    }
+};


### PR DESCRIPTION
Created migration to add missing 'signed' column to jobapps table and updated the original migration for fresh installations.

This fixes the "Column not found: j.signed" error when creating the applicant_data and view_applicants views.

https://claude.ai/code/session_018kCGjvLLQx9gtM7Ym5YNe5