### PR TITLE
Fix class name error - Change JobApp to Jobapp

### DIFF
--- a/app/Http/Controllers/ApplicationController.php
+++ b/app/Http/Controllers/ApplicationController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\KurraApp;
-use App\JobApp;
+use App\Jobapp;
 use App\Job;
 use Auth;
 use App\KuraAttachment;
@@ -391,11 +391,11 @@ class ApplicationController extends Controller
            if(!empty($insert1)){\DB::table('kura_certs')->insert($insert1);}
            if(!empty($insert2)){\DB::table('kura_memberships')->insert($insert2);}
            if(!empty($insert3)){\DB::table('kura_others')->insert($insert3);}
-           $app = JobApp::all()->where('token',$token)->first();
+           $app = Jobapp::all()->where('token',$token)->first();
             $req = \App\Required::all()->where('ref_token',$id);
            if (!empty($app)) 
             {
-                $apps = JobApp::findorfail($app->id);
+                $apps = Jobapp::findorfail($app->id);
                 $apps->app_status = 'Stage2';
                 $apps->save();
             }
@@ -410,7 +410,7 @@ class ApplicationController extends Controller
              $cert1 = array_filter($request->input('cert1'));
              $member = array_filter($request->input('member')); 
              $training = array_filter($request->input('training'));
-             $id = JobApp::all()->where('token',$token)->first();
+             $id = Jobapp::all()->where('token',$token)->first();
             // return $id;
 
               $req = \App\Required::all()->where('ref_token',$id->ref_token);
@@ -585,10 +585,10 @@ class ApplicationController extends Controller
            if(!empty($insert2)){\DB::table('kura_memberships')->insert($insert2);}
            if(!empty($insert3)){\DB::table('kura_others')->insert($insert3);}
       
-           $app = JobApp::all()->where('token',$token)->first();
+           $app = Jobapp::all()->where('token',$token)->first();
            if (!empty($app)) 
             {
-                $apps = JobApp::findorfail($app->id);
+                $apps = Jobapp::findorfail($app->id);
                 $apps->app_status = 'Stage2';
                 $apps->save();
             }
@@ -668,10 +668,10 @@ class ApplicationController extends Controller
            // if(!empty($insert1)){\DB::table('kura_certs')->insert($insert1);}
            if(!empty($insert2)){\DB::table('kura_referees')->insert($insert2);}
            if(!empty($insert3)){\DB::table('kura_employers')->insert($insert3);}
-           $app = JobApp::all()->where('token',$token)->first();
+           $app = Jobapp::all()->where('token',$token)->first();
            if (!empty($app)) 
             {
-                $apps = JobApp::findorfail($app->id);
+                $apps = Jobapp::findorfail($app->id);
                 $apps->app_status = 'Stage3';
                 $apps->save();
             }
@@ -865,10 +865,10 @@ class ApplicationController extends Controller
            // if(!empty($insert1)){\DB::table('kura_certs')->insert($insert1);}
            if(!empty($insert2)){\DB::table('kura_referees')->insert($insert2);}
            if(!empty($insert3)){\DB::table('kura_employers')->insert($insert3);}
-           $app = JobApp::all()->where('token',$token)->first();
+           $app = Jobapp::all()->where('token',$token)->first();
            if (!empty($app)) 
             {
-                $apps = JobApp::findorfail($app->id);
+                $apps = Jobapp::findorfail($app->id);
                 $apps->signed = $signed;
                 $apps->comments = $request->input('user_comments');
                 $apps->app_status = 'Complete';
@@ -921,10 +921,10 @@ class ApplicationController extends Controller
               $upl->file = implode(';', $files1);
               $upl->save();
              }
-         $app = JobApp::all()->where('token',$token)->first();
+         $app = Jobapp::all()->where('token',$token)->first();
            if (!empty($app)) 
             {
-                $apps = JobApp::findorfail($app->id);
+                $apps = Jobapp::findorfail($app->id);
                 $apps->app_status = 'Complete';
                 $apps->save();
             }
@@ -1354,11 +1354,11 @@ foreach(array_combine($arr, $arr4) as $f => $n) {
            if(!empty($insert1)){\DB::table('kura_certs')->insert($insert1);}
            if(!empty($insert2)){\DB::table('kura_memberships')->insert($insert2);}
            if(!empty($insert3)){\DB::table('kura_others')->insert($insert3);}
-           $check = JobApp::all()->where('token',$token)->first();
+           $check = Jobapp::all()->where('token',$token)->first();
            //  $req = \App\Required::all()->where('ref_token',$id);
            // if (!empty($app)) 
            //  {
-           //      $apps = JobApp::findorfail($app->id);
+           //      $apps = Jobapp::findorfail($app->id);
            //      $apps->app_status = 'Stage2';
            //      $apps->save();
            //  }

--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -585,7 +585,7 @@ public function stage($ref,$token)
           public function step_three($token)
     {
 
-      $job = \App\JobApp::all()->where('token',$token)->first();
+      $job = \App\Jobapp::all()->where('token',$token)->first();
       //return $job;
       $req =[];
         $checklist =ApplicantCreteria::all()->where('app_token',$token);


### PR DESCRIPTION
ISSUE FIXED:
- Error: Class "App\JobApp" not found in ApplicationController.php line 86
- Wrong class name capitalization causing class not found error

ROOT CAUSE:
- Model file is named Jobapp.php (lowercase 'app')
- Controllers were using JobApp (uppercase 'A' in App)
- PHP class names are case-sensitive

SOLUTION:
- Fixed import statement in ApplicationController.php (line 7)
- Replaced all 12 occurrences of JobApp with Jobapp in ApplicationController.php
- Fixed 1 occurrence in JobController.php (line 588)

FILES MODIFIED:
- app/Http/Controllers/ApplicationController.php
  - Line 7: use App\JobApp; → use App\Jobapp;
  - Lines 394, 398, 413, 588, 591, 671, 674, 868, 871, 924, 927, 1357
  - All JobApp references changed to Jobapp

- app/Http/Controllers/JobController.php
  - Line 588: \App\JobApp → \App\Jobapp

VERIFICATION:
- Confirmed model file exists as app/Jobapp.php
- No remaining instances of incorrect JobApp capitalization
- All references now match the actual model class name

IMPACT:
- Fixes cert1() method in ApplicationController
- Fixes step_three() method in JobController
- Application will no longer crash with class not found error
- All applicant-related functionality restored

https://claude.ai/code/session_01ChBs6LTkaLvi33q6AUJXeW