### PR TITLE
Add nonce to dashboard inline scripts to fix CSP violations

### DIFF
--- a/resources/views/data/dashboard.blade.php
+++ b/resources/views/data/dashboard.blade.php
@@ -373,7 +373,7 @@
 @role('Reports|Admin')
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script src="https://code.highcharts.com/modules/exporting.js"></script>
-<script>
+<script nonce="{{ $cspNonce ?? '' }}">
 $(document).ready(function() {
     // Base URL for API
     const apiBase = '/api/dashboard';


### PR DESCRIPTION
- Added nonce attribute to the main dashboard JavaScript code
- This fixes the "Executing inline script violates CSP" errors on the dashboard
- Highcharts external scripts don't need nonces as they're loaded from CDN

Note: Inline event handlers (onclick, onchange, etc.) still require 'unsafe-hashes' in the CSP policy or need to be converted to addEventListener patterns.

https://claude.ai/code/session_01ChBs6LTkaLvi33q6AUJXeW