### PR TITLE
Remove nonce generation from CSP middleware to fix inline script bloc…

### DIFF
--- a/app/Http/Middleware/ContentSecurityPolicy.php
+++ b/app/Http/Middleware/ContentSecurityPolicy.php
@@ -18,12 +18,8 @@ class ContentSecurityPolicy
     {
         $response = $next($request);
 
-        // Generate nonce for inline scripts
-        $nonce = base64_encode(random_bytes(16));
-        $request->attributes->set('csp_nonce', $nonce);
-
         // Build CSP header
-        $csp = $this->buildCspHeader($nonce);
+        $csp = $this->buildCspHeader();
 
         $response->headers->set('Content-Security-Policy', $csp);
 
@@ -33,14 +29,14 @@ class ContentSecurityPolicy
     /**
      * Build the CSP header
      */
-    private function buildCspHeader($nonce)
+    private function buildCspHeader()
     {
         $policies = [
             // Default source
             "default-src 'self' http: https: data: blob:",
 
             // Scripts - allow self, inline, eval (for DataTables), and CDNs
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'nonce-{$nonce}' https://code.jquery.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://code.highcharts.com https://maxcdn.bootstrapcdn.com",
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://code.jquery.com https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://code.highcharts.com https://maxcdn.bootstrapcdn.com",
 
             // Styles - allow inline styles
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://maxcdn.bootstrapcdn.com https://cdnjs.cloudflare.com",


### PR DESCRIPTION
…king

The CSP header was including a nonce which caused 'unsafe-inline' to be completely ignored by browsers. This was blocking ALL inline scripts even though 'unsafe-inline' was present in the policy.

Changes:
- Remove nonce generation from handle() method
- Remove nonce parameter from buildCspHeader()
- Remove 'nonce-{$nonce}' from script-src directive

Now 'unsafe-inline' will work correctly and allow all inline scripts to execute, including the "Add Requirement" button JavaScript.

https://claude.ai/code/session_01ChBs6LTkaLvi33q6AUJXeW