### PR TITLE
Fix undefined signed property error for missing checklist applicants

### DIFF
--- a/app/Http/Controllers/JobController.php
+++ b/app/Http/Controllers/JobController.php
@@ -382,6 +382,7 @@ public function checklist_details(Request $request)
                 $obj = new \stdClass();
                 $obj->token = $item->token;
                 $obj->app_id = null;
+                $obj->signed = null; // Add signed field for missing applicants
                 $obj->title = $jobTitle;
                 $obj->fname = $item->fname;
                 $obj->lname = $item->lname;

--- a/resources/views/data/reports/myapp.blade.php
+++ b/resources/views/data/reports/myapp.blade.php
@@ -133,13 +133,17 @@
                                         <td>{{ $user->current_employer ?? '-' }}</td>
                                         <td>{{ $user->current_position ?? '-' }}</td>
                                         <td class="text-center">
-                                            @if($user->signed)
+                                            @if(isset($user->signed) && $user->signed)
                                                 <span class="label label-success">
                                                     <i class="fa fa-check-circle"></i> Signed
                                                 </span>
-                                            @else
+                                            @elseif(isset($user->signed))
                                                 <span class="label label-warning">
                                                     <i class="fa fa-clock-o"></i> Pending
+                                                </span>
+                                            @else
+                                                <span class="label label-default">
+                                                    <i class="fa fa-minus"></i> N/A
                                                 </span>
                                             @endif
                                         </td>


### PR DESCRIPTION
Error: "Undefined property: stdClass::$signed" occurred when applicants were added via the missing checklist tokens logic.

Fixes:
1. Controller: Add $obj->signed = null in the missing applicants mapping function (line ~398) so all applicant objects have the signed property

2. View: Add isset() check before accessing $user->signed to safely handle cases where property might not exist
   - Shows "Signed" badge if signed = 1
   - Shows "Pending" badge if signed = 0
   - Shows "N/A" badge if property doesn't exist

This ensures the table displays correctly for all applicants, whether they came from jobapps table or were added from checklist-only records.

https://claude.ai/code/session_01ChBs6LTkaLvi33q6AUJXeW